### PR TITLE
Bug: has_and_belongs_to_many with primary_key

### DIFF
--- a/lib/mongoid/relations/referenced/many_to_many.rb
+++ b/lib/mongoid/relations/referenced/many_to_many.rb
@@ -54,13 +54,14 @@ module Mongoid
           documents.each do |doc|
             next unless doc
             append(doc)
+            doc_id = doc.send(__metadata.primary_key)
             if persistable? || _creating?
-              ids[doc.id] = true
+              ids[doc_id] = true
               save_or_delay(doc, docs, inserts)
             else
               existing = base.send(foreign_key)
-              unless existing.include?(doc.id)
-                existing.push(doc.id) and unsynced(base, foreign_key)
+              unless existing.include?(doc_id)
+                existing.push(doc_id) and unsynced(base, foreign_key)
               end
             end
           end

--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -3485,5 +3485,42 @@ describe Mongoid::Relations::Referenced::ManyToMany do
         expect(dog.fire_hydrant_ids).to eq([])
       end
     end
+
+    context "when assigns a value to a many to many" do
+      let(:fire_hydrant_one) do
+        FireHydrant.create(location: 'one')
+      end
+
+      before do
+        dog.fire_hydrants = [fire_hydrant_one]
+      end
+
+      it 'adds the pk value to the fk set' do
+        expect(dog.fire_hydrant_ids).to eq(
+          [fire_hydrant_one.location]
+        )
+      end
+    end
+
+    context "when assigns multiple values to a many to many" do
+      let(:fire_hydrant_one) do
+        FireHydrant.create(location: 'one')
+      end
+
+      let(:fire_hydrant_two) do
+        FireHydrant.create(location: 'two')
+      end
+
+      before do
+        dog.fire_hydrants = [fire_hydrant_one, fire_hydrant_two]
+      end
+
+      it 'adds the pk value to the fk set' do
+        # this test fails
+        expect(dog.fire_hydrant_ids).to eq(
+          [fire_hydrant_one.location, fire_hydrant_two.location]
+        )
+      end
+    end
   end
 end

--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -1676,6 +1676,24 @@ describe Mongoid::Relations::Referenced::ManyToMany do
         end
       end
     end
+
+    context "when primary_key is setted" do
+      let(:dog) do
+        Dog.new
+      end
+
+      let(:fire_hydrant) do
+        FireHydrant.new(location: 'one')
+      end
+
+      before do
+        dog.fire_hydrants.concat([fire_hydrant])
+      end
+
+      it 'adds the pk value to the fk set' do
+        expect(dog.fire_hydrant_ids).to eq([fire_hydrant.location])
+      end
+    end
   end
 
   describe "#count" do
@@ -3516,7 +3534,6 @@ describe Mongoid::Relations::Referenced::ManyToMany do
       end
 
       it 'adds the pk value to the fk set' do
-        # this test fails
         expect(dog.fire_hydrant_ids).to eq(
           [fire_hydrant_one.location, fire_hydrant_two.location]
         )


### PR DESCRIPTION
Example:
``` ruby
class FireHydrant
  include Mongoid::Document
  field :location, type: String
  has_and_belongs_to_many :dogs, primary_key: :name
end

class Dog
  include Mongoid::Document
  field :name, type: String
  has_and_belongs_to_many :fire_hydrants, primary_key: :location
end
```

``` ruby
fire_hydrant_one = FireHydrant.create(location: 'one')
fire_hydrant_two = FireHydrant.create(location: 'two')

dog.fire_hydrants = [fire_hydrant_one]
dog.fire_hydrant_ids #=> ['one']

dog.fire_hydrants = [fire_hydrant_one, fire_hydrant_two]
dog.fire_hydrant_ids
#=> [BSON::ObjectId('536b3a7a43616e1592e10300'), BSON::ObjectId('536b3a7a43616e1592e20300')]
```

I added tests to reproduce this behavior.