### PR TITLE
Preventing before_save callback from being called twice after a child create

### DIFF
--- a/lib/mongoid/relations/builders.rb
+++ b/lib/mongoid/relations/builders.rb
@@ -91,7 +91,9 @@ module Mongoid
           re_define_method("create_#{name}") do |*args|
             attributes, options = parse_args(*args)
             document = Factory.build(metadata.klass, attributes)
-            doc = send("#{name}=", document)
+            doc = _assigning do
+              send("#{name}=", document)
+            end
             doc.save
             save if new_record? && metadata.stores_foreign_key?
             doc

--- a/spec/app/models/label.rb
+++ b/spec/app/models/label.rb
@@ -8,14 +8,21 @@ class Label
   field :after_update_called, type: Mongoid::Boolean, default: false
   field :after_validation_called, type: Mongoid::Boolean, default: false
 
+  field :before_save_count, type: Integer, default: 0
+
   embedded_in :artist
   embedded_in :band
 
+  before_save :before_save_stub
   after_create :after_create_stub
   after_save :after_save_stub
   after_update :after_update_stub
   after_validation :after_validation_stub
   before_validation :cleanup
+
+  def before_save_stub
+    self.before_save_count += 1
+  end
 
   def after_create_stub
     self.after_create_called = true

--- a/spec/mongoid/interceptable_spec.rb
+++ b/spec/mongoid/interceptable_spec.rb
@@ -929,6 +929,21 @@ describe Mongoid::Interceptable do
             expect(band.reload.records.first.before_save_called).to be true
           end
         end
+
+        context "when the child is created" do
+
+          let!(:band) do
+            Band.create
+          end
+
+          let!(:label) do
+            band.create_label(name: 'Label')
+          end
+
+          it "only executes callback once" do
+            expect(label.before_save_count).to be 1
+          end
+        end
       end
 
       describe "#before_update" do


### PR DESCRIPTION
PR for #3631 