### PR TITLE
Added limit functionality to geo_near.

### DIFF
--- a/lib/mongoid/contextual/geo_near.rb
+++ b/lib/mongoid/contextual/geo_near.rb
@@ -92,9 +92,18 @@ module Mongoid
   max:        #{command[:maxDistance] || "N/A"}
   unique:     #{command[:unique].nil? ? true : command[:unique]}
   spherical:  #{command[:spherical] || false}>
+  limit:  #{command[:limit] || 100}>
 }
       end
 
+      def limit( value=nil )
+         if value
+            command[:limit] = value
+            self
+         else
+            stats["limit"]
+         end
+      end
       # Specify the maximum distance to find documents for, or get the value of
       # the document with the furthest distance.
       #


### PR DESCRIPTION
geo_near would not support the limit function, so it would always return 100 matches.  This change allows you to chain the limit() function and specify the number of results for geo_near.