### PR TITLE
refs #3889 #3888 checks added for :set for dynamic attributes and error ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For instructions on upgrading to newer versions, visit
 
 ### Resolved Issues
 
+* \#3888 raise UnknownAttributeError when 'set' is called on non existing field and Mongoid::Attributes::Dynamic is not included in model. (Shweta Kale)
+
+* \#3889 'set' will allow to set value of non existing field when Mongoid::Attributes::Dynamic is included in model. (Shweta Kale)
+
 * \#3792/\#3881 Fix many internal calls to #_id instead of #id to avoid issues
   when overloading #id (Gauthier Delacroix)
 

--- a/lib/mongoid/persistable/settable.rb
+++ b/lib/mongoid/persistable/settable.rb
@@ -22,7 +22,7 @@ module Mongoid
       def set(setters)
         prepare_atomic_operation do |ops|
           process_atomic_operations(setters) do |field, value|
-            send("#{field}=", value)
+            process_attribute(field.to_s, value)
             ops[atomic_attribute_name(field)] = attributes[field]
           end
           { "$set" => ops }

--- a/spec/mongoid/persistable/settable_spec.rb
+++ b/spec/mongoid/persistable/settable_spec.rb
@@ -136,4 +136,27 @@ describe Mongoid::Persistable::Settable do
       end
     end
   end
+
+  context "when dynamic attributes are not enabled" do
+    let(:account) do
+      Account.create
+    end
+
+    it "raises exception for an unknown attribute " do
+      expect {
+        account.set(somethingnew: "somethingnew")
+      }.to raise_error(Mongoid::Errors::UnknownAttribute)
+    end
+  end
+
+  context "when dynamic attributes enabled" do
+    let(:person) do
+      Person.create
+    end
+
+    it "updates non existing attribute" do
+      person.set(somethingnew: "somethingnew")
+      expect(person.reload.somethingnew).to eq "somethingnew"
+    end
+  end
 end


### PR DESCRIPTION
...on non-existing field

When we call process_attribute, it does all the checks for ensuring that
dynamic attributes are allowed and it also gives 'Mongoid::Errors::UnknownAttribute' when Mongoid::Attributes::Dynamic is not included in model.

refs #3889 #3889