### PR TITLE
changes done as per ruby style guide

### DIFF
--- a/lib/mongoid/atomic.rb
+++ b/lib/mongoid/atomic.rb
@@ -329,9 +329,7 @@ module Mongoid
     # @since 3.0.10
     def process_flagged_destroys
       _assigning do
-        flagged_destroys.each do |block|
-          block.call
-        end
+        flagged_destroys.each(&:call)
       end
       flagged_destroys.clear
     end
@@ -373,7 +371,7 @@ module Mongoid
     # @since 3.0.6
     def touch_atomic_updates(field = nil)
       updates = atomic_updates
-      return {} unless atomic_updates.has_key?("$set")
+      return {} unless atomic_updates.key?("$set")
       touches = {}
       updates["$set"].each_pair do |key, value|
         touches.merge!({ key => value }) if key =~ /updated_at|#{field}/

--- a/lib/mongoid/attributes.rb
+++ b/lib/mongoid/attributes.rb
@@ -58,7 +58,7 @@ module Mongoid
     #
     # @since 3.0.0
     def has_attribute?(name)
-      attributes.has_key?(name.to_s)
+      attributes.key?(name.to_s)
     end
 
     # Does the document have the provided attribute before it was assigned
@@ -74,7 +74,7 @@ module Mongoid
     #
     # @since 3.1.0
     def has_attribute_before_type_cast?(name)
-      attributes_before_type_cast.has_key?(name.to_s)
+      attributes_before_type_cast.key?(name.to_s)
     end
 
     # Read a value from the document attributes. If the value does not exist
@@ -119,7 +119,7 @@ module Mongoid
     # @since 3.1.0
     def read_attribute_before_type_cast(name)
       attr = name.to_s
-      if attributes_before_type_cast.has_key?(attr)
+      if attributes_before_type_cast.key?(attr)
         attributes_before_type_cast[attr]
       else
         read_attribute(attr)
@@ -256,9 +256,9 @@ module Mongoid
 
     def selection_included?(name, selection, field)
       if field && field.localized?
-        selection.has_key?("#{name}.#{::I18n.locale}")
+        selection.key?("#{name}.#{::I18n.locale}")
       else
-        selection.has_key?(name)
+        selection.key?(name)
       end
     end
 
@@ -288,7 +288,7 @@ module Mongoid
     #
     # @since 1.0.0
     def typed_value_for(key, value)
-      fields.has_key?(key) ? fields[key].mongoize(value) : value.mongoize
+      fields.key?(key) ? fields[key].mongoize(value) : value.mongoize
     end
 
     module ClassMethods

--- a/lib/mongoid/changeable.rb
+++ b/lib/mongoid/changeable.rb
@@ -40,9 +40,7 @@ module Mongoid
     #
     # @since 2.4.1
     def children_changed?
-      _children.any? do |child|
-        child.changed?
-      end
+      _children.any?(&:changed?)
     end
 
     # Get the attribute changes.
@@ -184,7 +182,7 @@ module Mongoid
     # @since 2.1.6
     def attribute_changed?(attr)
       attr = database_field_name(attr)
-      return false unless changed_attributes.has_key?(attr)
+      return false unless changed_attributes.key?(attr)
       changed_attributes[attr] != attributes[attr]
     end
 
@@ -228,7 +226,7 @@ module Mongoid
     #
     # @since 2.3.0
     def attribute_will_change!(attr)
-      unless changed_attributes.has_key?(attr)
+      unless changed_attributes.key?(attr)
         changed_attributes[attr] = read_attribute(attr).__deep_copy__
       end
     end

--- a/lib/mongoid/composable.rb
+++ b/lib/mongoid/composable.rb
@@ -97,7 +97,7 @@ module Mongoid
       # @since 2.1.8
       def prohibited_methods
         @prohibited_methods ||= MODULES.flat_map do |mod|
-          mod.instance_methods.map{ |m| m.to_sym }
+          mod.instance_methods.map(&:to_sym)
         end
       end
     end

--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -35,7 +35,7 @@ module Mongoid
     #
     # @since 3.0.9
     def configured?
-      sessions.has_key?(:default)
+      sessions.key?(:default)
     end
 
     # Connect to the provided database name on the default session.
@@ -169,9 +169,7 @@ module Mongoid
     #
     # @since 2.0.2
     def purge!
-      Sessions.default.collections.each do |collection|
-        collection.drop
-      end and true
+      Sessions.default.collections.each(&:drop) and true
     end
 
     # Truncate all data in all collections, but not the indexes.

--- a/lib/mongoid/document.rb
+++ b/lib/mongoid/document.rb
@@ -168,7 +168,7 @@ module Mongoid
       embedded_relations.each_pair do |name, meta|
         without_autobuild do
           relation, stored = send(name), meta.store_as
-          if attributes.has_key?(stored) || !relation.blank?
+          if attributes.key?(stored) || !relation.blank?
             if relation
               attributes[stored] = relation.as_document
             else
@@ -327,7 +327,7 @@ module Mongoid
       #
       # @since 1.0.0
       def _types
-        @_type ||= (descendants + [ self ]).uniq.map { |t| t.to_s }
+        @_type ||= (descendants + [ self ]).uniq.map(&:to_s)
       end
 
       # Set the i18n scope to overwrite ActiveModel.

--- a/lib/mongoid/fields.rb
+++ b/lib/mongoid/fields.rb
@@ -93,7 +93,7 @@ module Mongoid
     #
     # @since 2.4.0
     def apply_default(name)
-      unless attributes.has_key?(name)
+      unless attributes.key?(name)
         if field = fields[name]
           default = field.eval_default(self)
           unless default.nil? || field.lazy?
@@ -358,7 +358,7 @@ module Mongoid
         field_options = field.options
 
         Fields.options.each_pair do |option_name, handler|
-          if field_options.has_key?(option_name)
+          if field_options.key?(option_name)
             handler.call(self, field, field_options[option_name])
           end
         end

--- a/lib/mongoid/indexable.rb
+++ b/lib/mongoid/indexable.rb
@@ -142,7 +142,7 @@ module Mongoid
       #
       # @since 4.0.0
       def index_keys
-        index_specifications.map{ |spec| spec.key }
+        index_specifications.map(&:key)
       end
     end
   end

--- a/lib/mongoid/query_cache.rb
+++ b/lib/mongoid/query_cache.rb
@@ -131,7 +131,7 @@ module Mongoid
 
       private
 
-      def with_cache(context = :cursor, more = false, &block)
+      def with_cache(context = :cursor, more = false, &_block)
         return yield unless QueryCache.enabled?
         return yield if system_collection?
         key = cache_key.push(context)
@@ -140,7 +140,7 @@ module Mongoid
           docs = yield
           QueryCache.cache_table[key].push(*docs)
           docs
-        elsif QueryCache.cache_table.has_key?(key)
+        elsif QueryCache.cache_table.key?(key)
           instrument(key) { QueryCache.cache_table[key] }
         else
           QueryCache.cache_table[key] = yield

--- a/lib/mongoid/serializable.rb
+++ b/lib/mongoid/serializable.rb
@@ -97,10 +97,10 @@ module Mongoid
     #
     # @since 3.0.0
     def serialize_attribute(attrs, name, names, options)
-      if relations.has_key?(name)
+      if relations.key?(name)
         value = send(name)
         attrs[name] = value ? value.serializable_hash(options) : nil
-      elsif names.include?(name) && !fields.has_key?(name)
+      elsif names.include?(name) && !fields.key?(name)
         attrs[name] = read_attribute(name)
       elsif !attribute_missing?(name)
         attrs[name] = send(name)

--- a/lib/mongoid/sessions.rb
+++ b/lib/mongoid/sessions.rb
@@ -46,9 +46,7 @@ module Mongoid
       #
       # @since 3.1.0
       def disconnect
-        Threaded.sessions.values.each do |session|
-          session.disconnect
-        end
+        Threaded.sessions.values.each(&:disconnect)
       end
 
       # Get a session with the provided name.

--- a/lib/mongoid/validatable.rb
+++ b/lib/mongoid/validatable.rb
@@ -68,7 +68,7 @@ module Mongoid
     # @since 2.0.0.rc.1
     def read_attribute_for_validation(attr)
       attribute = database_field_name(attr)
-      if relations.has_key?(attribute)
+      if relations.key?(attribute)
         begin_validate
         relation = without_autobuild { send(attr) }
         exit_validate

--- a/spec/mongoid/copyable_spec.rb
+++ b/spec/mongoid/copyable_spec.rb
@@ -57,6 +57,7 @@ describe Mongoid::Copyable do
       context "when cloning a document with multiple languages field" do
 
         before do
+          I18n.enforce_available_locales = false
           I18n.locale = 'pt_BR'
           person.desc = "descrição"
           person.save

--- a/spec/mongoid/fields/localized_spec.rb
+++ b/spec/mongoid/fields/localized_spec.rb
@@ -81,6 +81,7 @@ describe Mongoid::Fields::Localized do
       context "when a locale is provided" do
 
         before do
+          I18n.enforce_available_locales = false
           ::I18n.locale = :de
         end
 

--- a/spec/mongoid/fields_spec.rb
+++ b/spec/mongoid/fields_spec.rb
@@ -18,6 +18,7 @@ describe Mongoid::Fields do
 
         before do
           product.description = "test"
+          I18n.enforce_available_locales = false
           ::I18n.locale = :de
           product.description = "The best"
         end

--- a/spec/mongoid/persistable/updatable_spec.rb
+++ b/spec/mongoid/persistable/updatable_spec.rb
@@ -217,6 +217,7 @@ describe Mongoid::Persistable::Updatable do
       end
 
       before do
+        I18n.enforce_available_locales = false
         ::I18n.locale = :de
         product.update_attribute(:description, "Die Bombe")
       end


### PR DESCRIPTION
1) Hash#has_key? has been depreciated in favour of Hash#key?
2) &block is unused variable , it would be better to name it starting with _.