### PR TITLE
Fix relations named "parent".

### DIFF
--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -7,8 +7,12 @@ module Mongoid
   module Traversable
     extend ActiveSupport::Concern
 
-    included do
-      attr_accessor :_parent
+    def _parent
+      @__parent
+    end
+
+    def _parent=(p)
+      @__parent = p
     end
 
     # Get all child +Documents+ to this +Document+, going n levels deep if

--- a/spec/mongoid/relations/referenced/many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_spec.rb
@@ -3555,4 +3555,27 @@ describe Mongoid::Relations::Referenced::Many do
       expect(person.posts.open).to eq([ post ])
     end
   end
+
+  context "when accessing a relation named parent" do
+    let!(:parent) do
+      Odd.create(name: "odd parent")
+    end
+
+    let(:child) do
+      Even.create(parent_id: parent.id, name: "original even child")
+    end
+
+    it "updates the child after accessing the parent" do
+      # Access parent relation on the child to make sure it is loaded
+      child.parent
+
+      new_child_name = "updated even child"
+
+      child.name = new_child_name
+      child.save!
+
+      reloaded = Even.find(child.id)
+      expect(reloaded.name).to eq(new_child_name)
+    end
+  end
 end


### PR DESCRIPTION
The @_parent variable defined in Traversable was colliding with the "@_#{name}" variables defined by Relations. Added an extra underscore to the name to protect against this.

Fixes #3911