### PR TITLE
Require rails only if Rails variable is present

### DIFF
--- a/lib/mongoid/railties/database.rake
+++ b/lib/mongoid/railties/database.rake
@@ -67,7 +67,7 @@ namespace :db do
 
   namespace :mongoid do
     task :load_models do
-      ::Rails.application.eager_load!
+      ::Rails.application.eager_load! if defined?(Rails)
     end
   end
 end


### PR DESCRIPTION
This change will allow to load this rake tasks outside Rails enviroment :).