### PR TITLE
Converts preloaded models to their actual filename when loading them

### DIFF
--- a/lib/rails/mongoid.rb
+++ b/lib/rails/mongoid.rb
@@ -15,7 +15,7 @@ module Rails
       app.config.paths["app/models"].each do |path|
         preload = ::Mongoid.preload_models
         if preload.resizable?
-          files = preload.map { |model| "#{path}/#{model}.rb" }
+          files = preload.map { |model| "#{path}/#{model.underscore}.rb" }
         else
           files = Dir.glob("#{path}/**/*.rb")
         end

--- a/spec/rails/mongoid_spec.rb
+++ b/spec/rails/mongoid_spec.rb
@@ -5,7 +5,7 @@ describe "Rails::Mongoid" do
   before(:all) do
     require "rails/mongoid"
     ::Mongoid.models.delete_if do |model|
-      ![ User, Account, Address ].include?(model)
+      ![ User, Account, Address, AddressNumber ].include?(model)
     end
   end
 
@@ -132,12 +132,13 @@ describe "Rails::Mongoid" do
       end
 
       before(:all) do
-        Mongoid.preload_models = ["user"]
+        Mongoid.preload_models = ["user", "AddressNumber"]
       end
 
       it "loads selected models only" do
         allow(Dir).to receive(:glob).with("/rails/root/app/models/**/*.rb").and_return(files)
         expect(Rails::Mongoid).to receive(:load_model).with("user")
+        expect(Rails::Mongoid).to receive(:load_model).with("address_number")
         expect(Rails::Mongoid).to receive(:load_model).with("address").never
         Rails::Mongoid.load_models(app)
       end


### PR DESCRIPTION
According to the documentation `preload_models` is either a Boolean or an Array of models to preload. Unfortunatelly specifing the model name (`User`) would not cause proper preloading on case sensitive file systems.

This commit fixes this and also adds support for preloading camel cased model names by calling `.underscore` on the given model name.