### PR TITLE
fix contextual memory multi field sort spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ For instructions on upgrading to newer versions, visit
 
 ### Resolved Issues
 
+* \#3935 fix multiple fields sorting on contextual memory. (chamnap)
+
 * \#3888 raise UnknownAttributeError when 'set' is called on non existing field and Mongoid::Attributes::Dynamic is not included in model. (Shweta Kale)
 
 * \#3889 'set' will allow to set value of non existing field when Mongoid::Attributes::Dynamic is included in model. (Shweta Kale)

--- a/lib/mongoid/contextual/memory.rb
+++ b/lib/mongoid/contextual/memory.rb
@@ -421,12 +421,11 @@ module Mongoid
       #
       # @since 3.0.0
       def in_place_sort(values)
-        values.keys.reverse.each do |field|
-          documents.sort! do |a, b|
+        documents.sort! do |a, b|
+          values.map do |field, direction|
             a_value, b_value = a[field], b[field]
-            value = compare(a_value.__sortable__, b_value.__sortable__)
-            values[field] < 0 ? value * -1 : value
-          end
+            direction * compare(a_value.__sortable__, b_value.__sortable__)
+          end.find { |value| !value.zero? } || 0
         end
       end
 

--- a/spec/mongoid/contextual/memory_spec.rb
+++ b/spec/mongoid/contextual/memory_spec.rb
@@ -926,8 +926,13 @@ describe Mongoid::Contextual::Memory do
         Address.new(street: "lenau", number: 5, name: "lenau")
       end
 
+      let(:kampuchea_krom) do
+        Address.new(street: "kampuchea krom", number: 5, name: "kampuchea krom")
+      end
+
       before do
         criteria.documents.unshift(lenau)
+        criteria.documents.unshift(kampuchea_krom)
       end
 
       context "when the sort is ascending" do
@@ -937,7 +942,7 @@ describe Mongoid::Contextual::Memory do
         end
 
         it "sorts the documents" do
-          expect(context.entries).to eq([ friedel, lenau, pfluger, hobrecht ])
+          expect(context.entries).to eq([ friedel, kampuchea_krom, lenau, pfluger, hobrecht ])
         end
 
         it "returns the context" do
@@ -952,7 +957,7 @@ describe Mongoid::Contextual::Memory do
         end
 
         it "sorts the documents" do
-          expect(context.entries).to eq([ hobrecht, pfluger, lenau, friedel ])
+          expect(context.entries).to eq([ hobrecht, pfluger, lenau, kampuchea_krom, friedel ])
         end
 
         it "returns the context" do


### PR DESCRIPTION
There is a bug on contextual memory when sorting multiple fields as mentioned in this issue, https://github.com/mongoid/mongoid/issues/3782.

This spec used to be fixed on https://github.com/mongoid/mongoid/pull/2664. However, it still got problem. Looking at the specs, `context.sort(number: 1, street: 1)` should sort by number first and only then by street. I just added a new address "Kampuchea Krom" to the test with a conflicting house number to verify the bug, and here is the result before this fix expects:

Street |Number
------------ | -------------
friedel|1
kampuchea-krom|5
pfluger|5
lenau|5
hobrecht|9

The expected result after the fix is then:

Street |Number
------------ | -------------
friedel|1
kampuchea-krom|5
lenau|5
pfluger|5
hobrecht|9