### PR TITLE
Add #find_or_create_by! to many associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ For instructions on upgrading to newer versions, visit
 
 ### New Features
 
+* \#3931 Add #find_or_create_by! method to many associations. (Tom Beynon)
+
 * \#3731 Add find_by! method. (Guillermo Iguaran)
 
 ### Resolved Issues

--- a/lib/mongoid/relations/many.rb
+++ b/lib/mongoid/relations/many.rb
@@ -98,6 +98,27 @@ module Mongoid
         find_or(:create, attrs, type, &block)
       end
 
+      # Find the first document given the conditions, or creates a new document
+      # with the conditions that were supplied. This will raise an error if validation fails.
+      #
+      # @example Find or create.
+      #   person.posts.find_or_create_by!(:title => "Testing")
+      #
+      # @overload find_or_create_by!(attributes = nil, type = nil)
+      #   @param [ Hash ] attributes The attributes to search or create with.
+      #   @param [ Class ] type The optional type of document to create.
+      #
+      # @overload find_or_create_by!(attributes = nil, type = nil)
+      #   @param [ Hash ] attributes The attributes to search or create with.
+      #   @param [ Class ] type The optional type of document to create.
+      #
+      # @raise [ Errors::Validations ] If validation failed.
+      #
+      # @return [ Document ] An existing document or newly created one.
+      def find_or_create_by!(attrs = {}, type = nil, &block)
+        find_or(:create!, attrs, type, &block)
+      end
+
       # Find the first +Document+ given the conditions, or instantiates a new document
       # with the conditions that were supplied
       #

--- a/spec/mongoid/persistable/creatable_spec.rb
+++ b/spec/mongoid/persistable/creatable_spec.rb
@@ -394,6 +394,47 @@ describe Mongoid::Persistable::Creatable do
           end
         end
       end
+
+      context "#find_or_create_by!" do
+
+        before do
+          container.vehicles.find_or_create_by!({ driver_id: driver.id }, Car)
+        end
+
+        it "creates the given type document" do
+          expect(container.vehicles.map(&:class)).to eq([ Car ])
+        end
+
+        it "creates with the given attributes" do
+          expect(container.vehicles.map(&:driver)).to eq([ driver ])
+        end
+
+        it "creates the correct number of documents" do
+          expect(container.vehicles.size).to eq(1)
+        end
+
+        context "when executing with a found document" do
+
+          before do
+            container.vehicles.find_or_create_by!({ driver_id: driver.id }, Car)
+          end
+
+          it "does not create an additional document" do
+            expect(container.vehicles.size).to eq(1)
+          end
+        end
+
+        context "when executing with an additional new document" do
+
+          before do
+            container.vehicles.find_or_create_by!({ driver_id: driver.id }, Truck)
+          end
+
+          it "creates the new additional document" do
+            expect(container.vehicles.size).to eq(2)
+          end
+        end
+      end
     end
   end
 

--- a/spec/mongoid/relations/referenced/many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_spec.rb
@@ -2560,6 +2560,136 @@ describe Mongoid::Relations::Referenced::Many do
     end
   end
 
+  describe "#find_or_create_by!" do
+
+    context "when the relation is not polymorphic" do
+
+      let(:person) do
+        Person.create
+      end
+
+      let!(:post) do
+        person.posts.create(title: "Testing")
+      end
+
+      context "when the document exists" do
+
+        let(:found) do
+          person.posts.find_or_create_by!(title: "Testing")
+        end
+
+        it "returns the document" do
+          expect(found).to eq(post)
+        end
+
+        it "keeps the document in the relation" do
+          expect(found.person).to eq(person)
+        end
+      end
+
+      context "when the document does not exist" do
+
+        context "when there is no criteria attached" do
+
+          let(:found) do
+            person.posts.find_or_create_by!(title: "Test") do |post|
+              post.content = "The Content"
+            end
+          end
+
+          it "sets the new document attributes" do
+            expect(found.title).to eq("Test")
+          end
+
+          it "returns a newly persisted document" do
+            expect(found).to be_persisted
+          end
+
+          it "calls the passed block" do
+            expect(found.content).to eq("The Content")
+          end
+
+          it "keeps the document in the relation" do
+            expect(found.person).to eq(person)
+          end
+        end
+
+        context "when a criteria is attached" do
+
+          let(:found) do
+            person.posts.recent.find_or_create_by!(title: "Test")
+          end
+
+          it "sets the new document attributes" do
+            expect(found.title).to eq("Test")
+          end
+
+          it "returns a newly persisted document" do
+            expect(found).to be_persisted
+          end
+
+          it "keeps the document in the relation" do
+            expect(found.person).to eq(person)
+          end
+        end
+      end
+    end
+
+    context "when the relation is polymorphic" do
+
+      let(:movie) do
+        Movie.create
+      end
+
+      let!(:rating) do
+        movie.ratings.create(value: 1)
+      end
+
+      context "when the document exists" do
+
+        let(:found) do
+          movie.ratings.find_or_create_by!(value: 1)
+        end
+
+        it "returns the document" do
+          expect(found).to eq(rating)
+        end
+
+        it "keeps the document in the relation" do
+          expect(found.ratable).to eq(movie)
+        end
+      end
+
+      context "when the document does not exist" do
+
+        let(:found) do
+          movie.ratings.find_or_create_by!(value: 3)
+        end
+
+        it "sets the new document attributes" do
+          expect(found.value).to eq(3)
+        end
+
+        it "returns a newly persisted document" do
+          expect(found).to be_persisted
+        end
+
+        it "keeps the document in the relation" do
+          expect(found.ratable).to eq(movie)
+        end
+
+        context "when validation fails" do
+
+          it "raises an error" do
+            expect {
+              movie.comments.find_or_create_by!(title: "")
+            }.to raise_error(Mongoid::Errors::Validations)
+          end
+        end
+      end
+    end
+  end
+
   describe "#find_or_initialize_by" do
 
     context "when the relation is not polymorphic" do

--- a/spec/mongoid/relations/referenced/many_to_many_spec.rb
+++ b/spec/mongoid/relations/referenced/many_to_many_spec.rb
@@ -2466,6 +2466,55 @@ describe Mongoid::Relations::Referenced::ManyToMany do
     end
   end
 
+  describe "#find_or_create_by!" do
+
+    context "when the relation is not polymorphic" do
+
+      let(:person) do
+        Person.create
+      end
+
+      let!(:preference) do
+        person.preferences.create(name: "Testing")
+      end
+
+      context "when the document exists" do
+
+        let(:found) do
+          person.preferences.find_or_create_by!(name: "Testing")
+        end
+
+        it "returns the document" do
+          expect(found).to eq(preference)
+        end
+      end
+
+      context "when the document does not exist" do
+
+        let(:found) do
+          person.preferences.find_or_create_by!(name: "Test")
+        end
+
+        it "sets the new document attributes" do
+          expect(found.name).to eq("Test")
+        end
+
+        it "returns a newly persisted document" do
+          expect(found).to be_persisted
+        end
+
+        context "when validation fails" do
+
+          it "raises an error" do
+            expect {
+              person.preferences.find_or_create_by!(name: "A")
+            }.to raise_error(Mongoid::Errors::Validations)
+          end
+        end
+      end
+    end
+  end
+
   describe "#find_or_initialize_by" do
 
     context "when the relation is not polymorphic" do


### PR DESCRIPTION
Pull request for Issue #3931. This adds a find_or_create_by! method to many associations.

    person.posts.find_or_create_by!(:title => 'Testing')