### PR TITLE
don't try to update counter_cache on frozen records

### DIFF
--- a/lib/mongoid/relations/counter_cache.rb
+++ b/lib/mongoid/relations/counter_cache.rb
@@ -116,7 +116,7 @@ module Mongoid
 
           before_destroy do
             if record = __send__(name)
-              record[cache_column] = (record[cache_column] || 0) - 1
+              record[cache_column] = (record[cache_column] || 0) - 1 unless record.frozen?
 
               if record.persisted?
                 record.class.decrement_counter(cache_column, record._id)

--- a/spec/mongoid/relations/counter_cache_spec.rb
+++ b/spec/mongoid/relations/counter_cache_spec.rb
@@ -287,4 +287,38 @@ describe Mongoid::Relations::CounterCache do
       end
     end
   end
+
+  describe "#add_counter_cache_callbacks" do
+
+    let(:person) do
+      Person.create
+    end
+
+    let!(:drug) do
+      person.drugs.create
+    end
+
+    context "when parent is not frozen" do
+
+      before do
+        drug.destroy
+      end
+
+      it "before_destroy updates counter cache" do
+        expect(person.drugs_count).to eq(0)
+      end
+    end
+
+    context "when parent is frozen" do
+
+      before do
+        person.destroy
+        drug.destroy
+      end
+
+      it "before_destroy doesn't update counter cache" do
+        expect(person.drugs_count).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sometimes actions on nested records with counter caches can be triggered on already destroyed records. When records are frozen, avoid attempting to update the counter_cache column.

Without this, counter_cache.rb:119 causes RuntimeError: can't modify frozen Hash.
