### PR TITLE
Allow pluck after with none. #3846

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ For instructions on upgrading to newer versions, visit
 
 ## 4.0.3 - Not released
 
+### New Features
+
+* \#3846 Allow #pluck when none is used in criteria. (Braulio Martinez)
+
 ## 4.0.2
 
 ### New Features

--- a/lib/mongoid/contextual/none.rb
+++ b/lib/mongoid/contextual/none.rb
@@ -51,6 +51,19 @@ module Mongoid
       # @since 4.0.0
       def exists?; false; end
 
+
+      # Allow pluck for null context.
+      #
+      # @example Allow pluck for null context.
+      #   context.pluck(:name)
+      #
+      # @param [ String, Symbol, Array ] field or fields to pluck.
+      #
+      # @return [ Array ] Emtpy Array
+      def pluck(*args)
+        []
+      end
+
       # Create the new null context.
       #
       # @example Create the new context.

--- a/spec/mongoid/contextual/none_spec.rb
+++ b/spec/mongoid/contextual/none_spec.rb
@@ -65,6 +65,21 @@ describe Mongoid::Contextual::None do
     end
   end
 
+  describe "#pluck" do
+
+    let!(:band) do
+      Band.create(name: "Depeche Mode")
+    end
+
+    let(:context) do
+      described_class.new(Band.where(name: "Depeche Mode"))
+    end
+
+    it "returns an empty array" do
+      expect(context.pluck(:id)).to eq([])
+    end
+  end
+
   describe "#first" do
 
     let!(:band) do


### PR DESCRIPTION
This addresses #3846 by adding the pluck method to the None class.

