### PR TITLE
[3.1.0-stable] explicitly set `I18n.enforce_available_locales` to false

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,3 +91,5 @@ end
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular("address_components", "address_component")
 end
+
+I18n.enforce_available_locales = false


### PR DESCRIPTION
mirrors PR to `master` https://github.com/mongoid/mongoid/pull/3899 on `3.1.0-stable`

i18n [`v0.7.0`](https://github.com/svenfuchs/i18n/blob/v0.7.0/CHANGELOG.md):
> `enforce_available_locales` now defaults to true with no deprecation message

Fixes the following spec failures and allows development on `3.1.0-stable`:
```
$ bundle exec rspec spec/mongoid/copyable_spec.rb:77:82:87:77:82:87 spec/mongoid/fields/localized_spec.rb:97:110:134:145:156:172:225:238:262:273:284:300:343:380 spec/mongoid/fields_spec.rb:33:384:405:542:563 spec/mongoid/persistence_spec.rb:1320:1324

Failed examples:

rspec ./spec/mongoid/copyable_spec.rb:77 # Mongoid::Copyable#clone when cloning a document with multiple languages field sets the pt_BR version
rspec ./spec/mongoid/copyable_spec.rb:82 # Mongoid::Copyable#clone when cloning a document with multiple languages field sets the english version
rspec ./spec/mongoid/copyable_spec.rb:87 # Mongoid::Copyable#clone when cloning a document with multiple languages field sets to nil an nonexistent lang
rspec ./spec/mongoid/copyable_spec.rb:77 # Mongoid::Copyable#dup when cloning a document with multiple languages field sets the pt_BR version
rspec ./spec/mongoid/copyable_spec.rb:82 # Mongoid::Copyable#dup when cloning a document with multiple languages field sets the english version
rspec ./spec/mongoid/copyable_spec.rb:87 # Mongoid::Copyable#dup when cloning a document with multiple languages field sets to nil an nonexistent lang
rspec ./spec/mongoid/fields/localized_spec.rb:97 # Mongoid::Fields::Localized#demongoize when the type is a string when a locale is provided when the value exists returns the string from the set locale
rspec ./spec/mongoid/fields/localized_spec.rb:110 # Mongoid::Fields::Localized#demongoize when the type is a string when a locale is provided when the value does not exist when not using fallbacks returns nil
rspec ./spec/mongoid/fields/localized_spec.rb:134 # Mongoid::Fields::Localized#demongoize when the type is a string when a locale is provided when the value does not exist when using fallbacks when fallbacks are defined when the first fallback translation exists returns the fallback translation
rspec ./spec/mongoid/fields/localized_spec.rb:145 # Mongoid::Fields::Localized#demongoize when the type is a string when a locale is provided when the value does not exist when using fallbacks when fallbacks are defined when another fallback translation exists returns the fallback translation
rspec ./spec/mongoid/fields/localized_spec.rb:156 # Mongoid::Fields::Localized#demongoize when the type is a string when a locale is provided when the value does not exist when using fallbacks when fallbacks are defined when the fallback translation does not exist returns nil
rspec ./spec/mongoid/fields/localized_spec.rb:172 # Mongoid::Fields::Localized#demongoize when the type is a string when a locale is provided when the value does not exist when using fallbacks when no fallbacks are defined returns nil
rspec ./spec/mongoid/fields/localized_spec.rb:225 # Mongoid::Fields::Localized#demongoize when the type is not a string when a locale is provided when the value exists returns the value from the set locale
rspec ./spec/mongoid/fields/localized_spec.rb:238 # Mongoid::Fields::Localized#demongoize when the type is not a string when a locale is provided when the value does not exist when not using fallbacks returns nil
rspec ./spec/mongoid/fields/localized_spec.rb:262 # Mongoid::Fields::Localized#demongoize when the type is not a string when a locale is provided when the value does not exist when using fallbacks when fallbacks are defined when the first fallback translation exists returns the fallback translation
rspec ./spec/mongoid/fields/localized_spec.rb:273 # Mongoid::Fields::Localized#demongoize when the type is not a string when a locale is provided when the value does not exist when using fallbacks when fallbacks are defined when another fallback translation exists returns the fallback translation
rspec ./spec/mongoid/fields/localized_spec.rb:284 # Mongoid::Fields::Localized#demongoize when the type is not a string when a locale is provided when the value does not exist when using fallbacks when fallbacks are defined when the fallback translation does not exist returns nil
rspec ./spec/mongoid/fields/localized_spec.rb:300 # Mongoid::Fields::Localized#demongoize when the type is not a string when a locale is provided when the value does not exist when using fallbacks when no fallbacks are defined returns nil
rspec ./spec/mongoid/fields/localized_spec.rb:343 # Mongoid::Fields::Localized#mongoize when the type is a string when a locale is provided returns the string in the set locale
rspec ./spec/mongoid/fields/localized_spec.rb:380 # Mongoid::Fields::Localized#mongoize when the type is not a string when a locale is provided returns the string in the set locale
rspec ./spec/mongoid/fields_spec.rb:33 # Mongoid::Fields#{field}_translations when the field is localized when translations exist returns all the translations
rspec ./spec/mongoid/fields_spec.rb:384 # Mongoid::Fields#getter when a field is localized when a single locale is set returns the set locale value
rspec ./spec/mongoid/fields_spec.rb:405 # Mongoid::Fields#getter when a field is localized when multiple locales are set returns the current locale value
rspec ./spec/mongoid/fields_spec.rb:542 # Mongoid::Fields#setter= when a field is localized when a locale is set sets the value in the default locale
rspec ./spec/mongoid/fields_spec.rb:563 # Mongoid::Fields#setter= when a field is localized when having multiple locales sets the value in both locales
rspec ./spec/mongoid/persistence_spec.rb:1320 # Mongoid::Persistence#update_attribute when persisting a localized field persists the en locale
rspec ./spec/mongoid/persistence_spec.rb:1324 # Mongoid::Persistence#update_attribute when persisting a localized field persists the de locale
```