### PR TITLE
[3.1.0-stable] Fixes specs mongodb 2.6

### DIFF
--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -100,7 +100,7 @@ describe Mongoid::Contextual::Atomic do
       end
 
       it "does not error on non initialized fields" do
-        smiths.reload.likes.should be_nil
+        smiths.reload.likes.should eq(0)
       end
     end
 
@@ -115,7 +115,7 @@ describe Mongoid::Contextual::Atomic do
       end
 
       it "does not error on non initialized fields" do
-        smiths.reload.likes.should be_nil
+        smiths.reload.likes.should eq(13)
       end
     end
 
@@ -130,7 +130,7 @@ describe Mongoid::Contextual::Atomic do
       end
 
       it "does not error on non initialized fields" do
-        smiths.reload.likes.should be_nil
+        smiths.reload.likes.should eq(10)
       end
     end
   end

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -133,7 +133,7 @@ describe Mongoid::Contextual::Atomic do
         smiths.reload.likes.should eq(10)
       end
     end
-  end
+  end if mongodb_version > "2.5"
 
   describe "#inc" do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,11 @@ def mongohq_connectable?
   ENV["MONGOHQ_REPL_PASS"].present?
 end
 
+def mongodb_version
+  session = Mongoid::Sessions.default
+  session.command(buildinfo: 1)["version"]
+end
+
 # Set the database that the spec suite connects to.
 Mongoid.configure do |config|
   config.load_configuration(CONFIG)


### PR DESCRIPTION
mirrors fix on `master` (https://github.com/mongoid/mongoid/commit/e93a4837b0266db46c24aae172e184f57c847b04) in `3.1.0-stable`

fixes failing specs due to changing behavior in MongoDB 2.6+