### PR TITLE
Fix specs on 3.1.0-stable

### DIFF
--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -100,7 +100,7 @@ describe Mongoid::Contextual::Atomic do
       end
 
       it "does not error on non initialized fields" do
-        smiths.reload.likes.should be_nil
+        smiths.reload.likes.should eq(0)
       end
     end
 
@@ -115,7 +115,7 @@ describe Mongoid::Contextual::Atomic do
       end
 
       it "does not error on non initialized fields" do
-        smiths.reload.likes.should be_nil
+        smiths.reload.likes.should eq(13)
       end
     end
 
@@ -130,7 +130,7 @@ describe Mongoid::Contextual::Atomic do
       end
 
       it "does not error on non initialized fields" do
-        smiths.reload.likes.should be_nil
+        smiths.reload.likes.should eq(10)
       end
     end
   end

--- a/spec/mongoid/contextual/atomic_spec.rb
+++ b/spec/mongoid/contextual/atomic_spec.rb
@@ -133,7 +133,7 @@ describe Mongoid::Contextual::Atomic do
         smiths.reload.likes.should eq(10)
       end
     end
-  end
+  end if mongodb_version > "2.5"
 
   describe "#inc" do
 

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -4726,7 +4726,7 @@ describe Mongoid::Criteria do
     end
 
     it "executes the criteria while properly giving the hint to Mongo" do
-      expect { criteria.to_ary }.to raise_error(Moped::Errors::QueryFailure,  %r{failed with error 10113: "bad hint"})
+      expect { criteria.to_ary }.to raise_error(Moped::Errors::QueryFailure)
     end
   end
 
@@ -4741,7 +4741,7 @@ describe Mongoid::Criteria do
     end
 
     it "executes the criteria while properly giving the hint to Mongo" do
-      expect { criteria.to_ary }.to raise_error(Moped::Errors::QueryFailure,  %r{failed with error 10113: "bad hint"})
+      expect { criteria.to_ary }.to raise_error(Moped::Errors::QueryFailure)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,3 +91,5 @@ end
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular("address_components", "address_component")
 end
+
+I18n.enforce_available_locales = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,11 @@ def mongohq_connectable?
   ENV["MONGOHQ_REPL_PASS"].present?
 end
 
+def mongodb_version
+  session = Mongoid::Sessions.default
+  session.command(buildinfo: 1)["version"]
+end
+
 # Set the database that the spec suite connects to.
 Mongoid.configure do |config|
   config.load_configuration(CONFIG)


### PR DESCRIPTION
Some specs fail on `3.1.0-stable` because of updated dependencies. This PR updates specs to pass, mirroring changes on `master`. Hope this helps! :koala: 

 **1. i18n  [`v0.7.0`](https://github.com/svenfuchs/i18n/blob/v0.7.0/CHANGELOG.md) `enforce_available_locales` now defaults to true:**
fix mirrors PR to `master` (https://github.com/mongoid/mongoid/pull/3899)

**2. Changing behavior in MongoDB 2.6+:**
fix mirrors commit to `master` (https://github.com/mongoid/mongoid/commit/e93a4837b0266db46c24aae172e184f57c847b04)

**3. Moped::Errors::QueryFailure message change:**
fix mirrors commit to `master` (https://github.com/mongoid/mongoid/commit/fa57fca58a19b7eba4ac03cdaacee57a8924145e)