### PR TITLE
add ignore_type_attribute to configuration

### DIFF
--- a/lib/mongoid/config.rb
+++ b/lib/mongoid/config.rb
@@ -18,6 +18,7 @@ module Mongoid
 
     option :include_root_in_json, default: false
     option :include_type_for_serialization, default: false
+    option :ignore_type_attribute, default: false
     option :preload_models, default: false
     option :raise_not_found_error, default: true
     option :scope_overwrite_exception, default: false

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -335,7 +335,7 @@ module Mongoid
     def only(*args)
       return clone if args.flatten.empty?
       args = args.flatten
-      if klass.hereditary?
+      if klass.hereditary? && !::Mongoid::Config.ignore_type_attribute?
         super(*args.push(:_type))
       else
         super(*args)
@@ -550,7 +550,8 @@ module Mongoid
     def type_selectable?
       klass.hereditary? &&
         !selector.keys.include?("_type") &&
-        !selector.keys.include?(:_type)
+        !selector.keys.include?(:_type) &&
+        !::Mongoid::Config.ignore_type_attribute?
     end
 
     # Get the selector for type selection.

--- a/lib/mongoid/factory.rb
+++ b/lib/mongoid/factory.rb
@@ -17,7 +17,7 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     def build(klass, attributes = nil)
       type = (attributes || {})["_type"]
-      if type && klass._types.include?(type)
+      if type && klass._types.include?(type) && !::Mongoid::Config.ignore_type_attribute?
         type.constantize.new(attributes)
       else
         klass.new(attributes)
@@ -38,7 +38,7 @@ module Mongoid
     # @return [ Document ] The instantiated document.
     def from_db(klass, attributes = nil, selected_fields = nil)
       type = (attributes || {})["_type"]
-      if type.blank?
+      if type.blank? || ::Mongoid::Config.ignore_type_attribute?
         klass.instantiate(attributes, selected_fields)
       else
         type.camelize.constantize.instantiate(attributes, selected_fields)

--- a/spec/mongoid/config_spec.rb
+++ b/spec/mongoid/config_spec.rb
@@ -107,6 +107,10 @@ describe Mongoid::Config do
         expect(described_class.include_type_for_serialization).to be false
       end
 
+      it "sets the ignore type attribute option" do
+        expect(described_class.ignore_type_attribute).to be false
+      end
+
       it "sets the scope overwrite option" do
         expect(described_class.scope_overwrite_exception).to be false
       end
@@ -151,6 +155,10 @@ describe Mongoid::Config do
 
         it "sets the include type with serialization option" do
           expect(described_class.include_type_for_serialization).to be false
+        end
+
+        it "sets the ignore type attribute option" do
+          expect(described_class.ignore_type_attribute).to be false
         end
 
         it "sets the scope overwrite option" do

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -2707,6 +2707,20 @@ describe Mongoid::Criteria do
       it "adds _type to the fields" do
         expect(criteria.options[:fields]["_type"]).to eq(1)
       end
+
+      context "when ignore_type_attribute is true" do
+        before do
+          ::Mongoid::Config.ignore_type_attribute = true
+        end
+
+        after do
+          ::Mongoid::Config.ignore_type_attribute = false
+        end
+
+        it "does not add _type to the fields" do
+          expect(criteria.options[:fields]["_type"]).to be_nil
+        end
+      end
     end
 
     context "when limiting to embedded documents" do

--- a/spec/mongoid/factory_spec.rb
+++ b/spec/mongoid/factory_spec.rb
@@ -41,6 +41,20 @@ describe Mongoid::Factory do
         it "instantiates the subclass" do
           expect(person.class).to eq(Doctor)
         end
+
+        context "when ignore_type_attribute is true" do
+          before do
+            ::Mongoid::Config.ignore_type_attribute = true
+          end
+
+          after do
+            ::Mongoid::Config.ignore_type_attribute = false
+          end
+
+          it "instantiates the calling class" do
+            expect(person.class).to eq(Person)
+          end
+        end
       end
 
       context "when type is an empty string" do
@@ -125,6 +139,20 @@ describe Mongoid::Factory do
 
         it "sets the attributes" do
           expect(document.title).to eq("Sir")
+        end
+
+        context "when ignore_type_attribute is true" do
+          before do
+            ::Mongoid::Config.ignore_type_attribute = true
+          end
+
+          after do
+            ::Mongoid::Config.ignore_type_attribute = false
+          end
+
+          it "instantiates the calling class" do
+            expect(document.class).to eq(Address)
+          end
         end
       end
 


### PR DESCRIPTION
Setting `Mongoid::Configuration.ignore_type_attribute=true` will cause Mongoid to ignore the _type
attribute on queries where normal inheritance rules would apply that criteria, and will also ignore _type when marshaling objects from the database (preferring to use the calling class instead)

This fixes a situation I encountered wherein I was versioning document models by incrementing the module namespace they were a part of, but I wanted my existing documents to continue being fetched/queried by the new V2 document model.