### PR TITLE
Fix default_scope sometimes generating an unwanted field because of a complex query

### DIFF
--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -31,7 +31,7 @@ module Mongoid
     def apply_default_scoping
       if default_scoping
         default_scoping.call.selector.each do |field, value|
-          attributes[field] = value unless value.respond_to?(:each_pair)
+          attributes[field] = value unless value.respond_to?(:each)
         end
       end
     end

--- a/spec/app/models/audio.rb
+++ b/spec/app/models/audio.rb
@@ -1,5 +1,5 @@
 class Audio
   include Mongoid::Document
   field :likes, type: Integer
-  default_scope ->{ where(:likes.gt => 100) }
+  default_scope ->{ self.or({:likes => nil}, {:likes.gt => 100}) }
 end

--- a/spec/mongoid/document_spec.rb
+++ b/spec/mongoid/document_spec.rb
@@ -251,7 +251,7 @@ describe Mongoid::Document do
         end
 
         it "does not set the default scoping" do
-          expect(audio.likes).to be_nil
+          expect(audio.attributes.except('_id')).to be_empty
         end
       end
     end


### PR DESCRIPTION
This fixes #3723. The previous code was looking for "#each_pair", thus expecting a complex query to be a hash, but a scope like the following:

```ruby
default_scope ->{ self.or({:likes => nil}, {:likes.gt => 100}) }
```

creates an array of hashes. I think looking for "#each" instead is the best solution.