### PR TITLE
Avoid "Missing attribute: '_id'" error when using methods only or without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ For instructions on upgrading to newer versions, visit
 
 * \#3993 Fixes issue where `dup`/`clone` fails for embedded documents that use store_as without using Mongoid::Atributes::Dynamic
 
+* \#3740 Fixes `Missing attribute: '_id'` error when using methods only or without (dx7)
+
 ## 4.0.2
 
 ### New Features

--- a/lib/mongoid/criteria.rb
+++ b/lib/mongoid/criteria.rb
@@ -335,11 +335,29 @@ module Mongoid
     def only(*args)
       return clone if args.flatten.empty?
       args = args.flatten
+      if (args & [:_id, :id, "_id", "id"]).empty?
+        args.unshift(:_id)
+      end
       if klass.hereditary?
         super(*args.push(:_type))
       else
         super(*args)
       end
+    end
+
+    # Overriden to exclude _id from the fields.
+    #
+    # @example Exclude fields returned from the database.
+    #   Band.without(:name)
+    #
+    # @param [ Array<Symbol> ] args The names of the fields.
+    #
+    # @return [ Criteria ] The cloned criteria.
+    #
+    # @since 4.0.3
+    def without(*args)
+      args -= [:_id, :id, "_id", "id"]
+      super(*args)
     end
 
     # Returns true if criteria responds to the given method.

--- a/spec/mongoid/criteria_spec.rb
+++ b/spec/mongoid/criteria_spec.rb
@@ -752,8 +752,8 @@ describe Mongoid::Criteria do
       Band.only(:name)
     end
 
-    it "returns the fields minus type" do
-      expect(criteria.field_list).to eq([ "name" ])
+    it "returns the fields with required _id minus type" do
+      expect(criteria.field_list).to eq([ "_id", "name" ])
     end
   end
 
@@ -2635,6 +2635,19 @@ describe Mongoid::Criteria do
         end
       end
 
+      context "when not including id" do
+
+        let(:criteria) do
+          Band.only(:name)
+        end
+
+        it "responds to id anyway" do
+          expect {
+            criteria.first.id
+          }.to_not raise_error
+        end
+      end
+
       context "when passing an array" do
 
         let(:criteria) do
@@ -2718,7 +2731,7 @@ describe Mongoid::Criteria do
         end
 
         it "properly uses the database field name" do
-          expect(criteria.options).to eq(fields: { "mobile_phones" => 1 })
+          expect(criteria.options).to eq(fields: { "_id" => 1, "mobile_phones" => 1 })
         end
       end
     end
@@ -3431,6 +3444,10 @@ describe Mongoid::Criteria do
 
   describe "#without" do
 
+    let!(:person) do
+      Person.create!(username: "davinci", age: 50, pets: false)
+    end
+
     context "when omitting to embedded documents" do
 
       context "when the embedded documents are aliased" do
@@ -3442,6 +3459,23 @@ describe Mongoid::Criteria do
         it "properly uses the database field name" do
           expect(criteria.options).to eq(fields: { "mobile_phones" => 0 })
         end
+      end
+    end
+
+    context "when excluding id" do
+
+      let(:criteria) do
+        Person.without(:_id, :id, "_id", "id")
+      end
+
+      it "does not raise error" do
+        expect {
+          criteria.first.id
+        }.to_not raise_error
+      end
+
+      it "returns id anyway" do
+        expect(criteria.first.id).to_not be_nil
       end
     end
   end


### PR DESCRIPTION
Force to use '_id' on method only and don't permit to remove '_id' with
method without.

Fixes #3740