### PR TITLE
Mongoid::Relations::Proxy#public_send should not be delegated to @target

### DIFF
--- a/lib/mongoid/relations/proxy.rb
+++ b/lib/mongoid/relations/proxy.rb
@@ -12,7 +12,7 @@ module Mongoid
       # We undefine most methods to get them sent through to the target.
       instance_methods.each do |method|
         undef_method(method) unless
-          method =~ /(^__|^send|^object_id|^respond_to|^tap|extend_proxy|extend_proxies)/
+          method =~ /(^__|^send|^object_id|^respond_to|^tap|^public_send|extend_proxy|extend_proxies)/
       end
 
       include Threaded::Lifecycle

--- a/spec/mongoid/relations/proxy_spec.rb
+++ b/spec/mongoid/relations/proxy_spec.rb
@@ -2,6 +2,34 @@ require "spec_helper"
 
 describe Mongoid::Relations::Proxy do
 
+  describe "#find" do
+    let(:person) do
+      Person.create
+    end
+
+    let(:messages) do
+      person.messages
+    end
+
+    let(:msg1) do
+      messages.create(body: 'msg1')
+    end
+
+    it "returns nil with no arguments" do
+      expect(messages.find).to be_nil
+      expect(messages.send(:find)).to be_nil
+      expect(messages.__send__(:find)).to be_nil
+      expect(messages.public_send(:find)).to be_nil
+    end
+
+    it "returns the object corresponding to the id" do
+      expect(messages.find(msg1.id)).to eq(msg1)
+      expect(messages.send(:find, msg1.id)).to eq(msg1)
+      expect(messages.__send__(:find, msg1.id)).to eq(msg1)
+      expect(messages.public_send(:find, msg1.id)).to eq(msg1)
+    end
+  end
+
   describe "#extend" do
 
     before(:all) do


### PR DESCRIPTION
Quite hard to see where does the problem comes but I finally managed to find why does `public_send(:find)` does not behave the same as `find`: http://stackoverflow.com/questions/29695736/mongoid-embedded-collection-response-to-find

The pull request is really simple, and I added a test that fails without this PR.