### PR TITLE
ensure .heriditary? returns true or false, not nil.

### DIFF
--- a/lib/mongoid/traversable.rb
+++ b/lib/mongoid/traversable.rb
@@ -161,7 +161,7 @@ module Mongoid
       #
       # @return [ true, false ] True if hereditary, false if not.
       def hereditary?
-        Mongoid::Document > superclass
+        !!(Mongoid::Document > superclass)
       end
 
       # When inheriting, we want to copy the fields from the parent class and

--- a/spec/mongoid/traversable_spec.rb
+++ b/spec/mongoid/traversable_spec.rb
@@ -71,14 +71,14 @@ describe Mongoid::Traversable do
     context "when the document is a subclass" do
 
       it "returns true" do
-        expect(Circle).to be_hereditary
+        expect(Circle.hereditary?).to be true
       end
     end
 
     context "when the document is not a subclass" do
 
       it "returns false" do
-        expect(Shape).to_not be_hereditary
+        expect(Shape.hereditary?).to be false
       end
     end
   end


### PR DESCRIPTION
`.hereditary?` returns nil for the parent. Small, but caused an issue for me. Fixed tests to ensure strict true/false checking.