### PR TITLE
Use sublcass context when calling a scope defined in a superclass

### DIFF
--- a/lib/mongoid/scopable.rb
+++ b/lib/mongoid/scopable.rb
@@ -325,7 +325,8 @@ module Mongoid
         singleton_class.class_eval do
           define_method name do |*args|
             scoping = _declared_scopes[name]
-            scope, extension = scoping[:scope][*args], scoping[:extension]
+            scope = instance_exec(*args, &scoping[:scope])
+            extension = scoping[:extension]
             criteria = with_default_scope.merge(scope || queryable)
             criteria.extend(extension)
             criteria


### PR DESCRIPTION
Example:

```ruby
class Shape
  scope :visible, -> { large }
  scope :large, -> { all }
end

class Circle < Shape
  scope :large, -> { where(radius: 5) }
end
```

`Circle.visible.selector` returns `{}`, instead of `{ "radius" => 5 }`.

ActiveRecord also uses `instance_exec` when [calling scopes](https://github.com/rails/rails/blob/6b5f815cf832524ebcf7585a44bbb7e291423c71/activerecord/lib/active_record/scoping/named.rb#L151).

This should also fix #3599.