### PR TITLE
rake tasks should use Mongoid.logger

### DIFF
--- a/lib/mongoid/tasks/database.rb
+++ b/lib/mongoid/tasks/database.rb
@@ -107,7 +107,7 @@ module Mongoid
 
       private
       def logger
-        @logger ||= Logger.new($stdout)
+        Mongoid.logger
       end
     end
   end


### PR DESCRIPTION
Just a suggestion. It seems like it would be nice to enable the same logger configuration in rake tasks as are allowed during regular mongoid operation.
